### PR TITLE
Use accent red across the app

### DIFF
--- a/Sprayd/App/SpraydApp.swift
+++ b/Sprayd/App/SpraydApp.swift
@@ -12,6 +12,7 @@ struct SpraydApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .tint(.accentRed)
         }
     }
 }

--- a/Sprayd/Assets/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Sprayd/Assets/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.255",
+          "green" : "0.298",
+          "red" : "0.894"
+        }
+      },
       "idiom" : "universal"
     }
   ],


### PR DESCRIPTION
Applies AccentRed globally across the app by setting the root tint and matching the AccentColor asset to the same color from Design.swift